### PR TITLE
fix deploy BrokenETHOptions

### DIFF
--- a/migrations/1_initial_migration.js
+++ b/migrations/1_initial_migration.js
@@ -46,7 +46,7 @@ module.exports = async function (deployer, network, [account]) {
     await deployer.deploy(StakingWBTC, HEGIC.address, WBTC.address)
     await deployer.deploy(StakingETH, HEGIC.address)
 
-    await deployer.deploy(ETHOptions, PriceProvider.address, StakingETH.address, ETHPool.address)
+    await deployer.deploy(ETHOptions, PriceProvider.address, StakingETH.address)
     await deployer.deploy(
       WBTCOptions,
       BTCPriceProvider.address,


### PR DESCRIPTION
When I tried to deploy contracts locally, it seems constructor arguments of BrokenETHOptions expects two arguments but three were given. So I removed ETHPool address.


### All Submissions:

- [x] Have you followed the guidelines in our [Contributing document](CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Does your submission pass tests?
- [x] Have you lint your code locally prior to submission?
